### PR TITLE
[mysql] add: switch to latest version of mariadb

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -24,7 +24,7 @@ services:
     command: /bin/sh -c "java -Xmx4g -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005 -Ddb.password=${MYSQL_USER_PASSWORD:-P@ssword1} -Doncokb.token=${ONCOKBTOKEN} -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal_session:5000/api/sessions/my_portal/ -jar webapp-runner.jar /cbioportal-webapp"
   cbioportal_database:
     restart: unless-stopped
-    image: mysql:5.7
+    image: mariadb:latest
     container_name: cbioportal_database_container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-P@ssword1}
@@ -34,7 +34,10 @@ services:
     volumes:
      - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
      - ./data/seed-cbioportal_hg19_v2.7.3.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - cbioportal_data:/var/lib/mysql 
+     - cbioportal_data:/var/lib/mysql
+    command:
+     - --character-set-server=latin1
+     - --collation-server=latin1_swedish_ci
     ports:
       - "3306:3306"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: /bin/sh -c "java -Xms2g -Xmx4g -Ddb.password=${MYSQL_USER_PASSWORD:-P@ssword1} -Doncokb.token=${ONCOKBTOKEN} -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal_session:5000/api/sessions/my_portal/ -jar webapp-runner.jar /cbioportal-webapp"
   cbioportal_database:
     restart: unless-stopped
-    image: mysql:5.7
+    image: mariadb:latest
     container_name: cbioportal_database_container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-P@ssword1}
@@ -29,7 +29,10 @@ services:
     volumes:
      - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
      - ./data/seed-cbioportal_hg19_v2.7.3.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - cbioportal_data:/var/lib/mysql 
+     - cbioportal_data:/var/lib/mysql
+    command:
+     - --character-set-server=latin1
+     - --collation-server=latin1_swedish_ci
     networks:
      - cbioportal_net
   cbioportal_session:


### PR DESCRIPTION
MariaDB is the standard server for the MySQL protocol in Debian since release 9.
Also, MariaDB includes performance improvements and is (different from MySQL 8) fully compatible with cBioPortal if the charset and collation is set to the same value as the one of the MySQL 5.7 server.

See: https://github.com/nr23730/cbioportal/runs/806922224