### PR TITLE
Migrate from MIRACUM HAPI to official HAPI FHIR Server

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -89,21 +89,22 @@ services:
       - cbioportal_net
   hapiserver:
     restart: unless-stopped
-    image: docker.miracum.org/miracum-data/hapi-fhir-jpaserver:v8.1.3
+    image: hapiproject/hapi:latest
     container_name: cbioportal_fhirspark_hapiserver
     ports:
       - "8082:8080"
     depends_on:
       - hapi-postgres
     environment:
-      server.address: "http://hapiserver:8080/fhir/"
-      reuse_cached_search_results_millis: 5000
-      datasource.url: "jdbc:postgresql://hapi-postgres:5432/hapi?currentSchema=public"
-      datasource.username: hapiserver
-      datasource.password: ${POSTGRES_USER_PASSWORD:-P@ssword2}
-      hibernate.dialect: org.hibernate.dialect.PostgreSQL95Dialect
-      datasource.driver: org.postgresql.Driver
-      validation.requests.enabled: "false"
+      hapi.fhir.server_address: "http://hapiserver:8080/fhir/"
+      hapi.fhir.reuse_cached_search_results_millis: 5000
+      hapi.fhir.implementationguides.genomics-reporting.name: hl7.fhir.uv.genomics-reporting
+      hapi.fhir.implementationguides.genomics-reporting.version: 1.0.0
+      hapi.fhir.validation.requests_enabled: 'true'
+      spring.datasource.url: "jdbc:postgresql://hapi-postgres:5432/hapi?currentSchema=public"
+      spring.datasource.username: hapiserver
+      spring.datasource.password: ${POSTGRES_USER_PASSWORD:-P@ssword2}
+      spring.datasource.driverClassName: org.postgresql.Driver
     networks:
       - cbioportal_net
   hapi-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,19 +73,20 @@ services:
       - cbioportal_net
   hapiserver:
     restart: unless-stopped
-    image: docker.miracum.org/miracum-data/hapi-fhir-jpaserver:v8.1.3
+    image: hapiproject/hapi:latest
     container_name: cbioportal_fhirspark_hapiserver
     depends_on:
       - hapi-postgres
     environment:
-      server.address: "http://hapiserver:8080/fhir/"
-      reuse_cached_search_results_millis: 5000
-      datasource.url: "jdbc:postgresql://hapi-postgres:5432/hapi?currentSchema=public"
-      datasource.username: hapiserver
-      datasource.password: ${POSTGRES_USER_PASSWORD:-P@ssword2}
-      hibernate.dialect: org.hibernate.dialect.PostgreSQL95Dialect
-      datasource.driver: org.postgresql.Driver
-      validation.requests.enabled: "false"
+      hapi.fhir.server_address: "http://hapiserver:8080/fhir/"
+      hapi.fhir.reuse_cached_search_results_millis: 5000
+      hapi.fhir.implementationguides.genomics-reporting.name: hl7.fhir.uv.genomics-reporting
+      hapi.fhir.implementationguides.genomics-reporting.version: 1.0.0
+      hapi.fhir.validation.requests_enabled: 'true'
+      spring.datasource.url: "jdbc:postgresql://hapi-postgres:5432/hapi?currentSchema=public"
+      spring.datasource.username: hapiserver
+      spring.datasource.password: ${POSTGRES_USER_PASSWORD:-P@ssword2}
+      spring.datasource.driverClassName: org.postgresql.Driver
     networks:
       - cbioportal_net
   hapi-postgres:


### PR DESCRIPTION
The FHIR Server that is currently being used is deprecated.
Apart from the logo it is basically the same as the official HAPI FHIR Server. So my proposal would be to use that one. 
As they are basically the same it's possible to change this without losing data that is already stored inside the Postgres database.

This now also supports the option to include implementation guides. For now I configured it to use the genomics-reporting guide that FhirSpark is designed for and tested with. 