### PR TITLE
Persistent Genome Nexus database

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -152,6 +152,10 @@ services:
   genomenexus_db:
     image: docker.miracum.org/cbioportal/genome-nexus-db:${RELEASE:-latest}
     build: https://github.com/genome-nexus/genome-nexus-importer.git
+    ports:
+      - "27018:27017"
+    volumes:
+      - genomenexus_data:/bitnami/mongodb
     environment:
       - REF_ENSEMBL_VERSION=grch37_ensembl92
       - SPECIES=homo_sapiens
@@ -175,3 +179,4 @@ volumes:
   cbioportal_data:
   cbioportal_session_data:
   fhir_data:
+  genomenexus_data:

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -79,6 +79,8 @@ services:
       - cbioportal_net
   genomenexus_db:
     image: docker.miracum.org/cbioportal/genome-nexus-db:${RELEASE:-latest}
+    volumes:
+      - genomenexus_data:/bitnami/mongodb
     environment:
       - REF_ENSEMBL_VERSION=grch37_ensembl92
       - SPECIES=homo_sapiens
@@ -99,3 +101,4 @@ networks:
 volumes:
   cbioportal_data:
   cbioportal_session_data:
+  genomenexus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,8 @@ services:
       - cbioportal_net
   genomenexus_db:
     image: docker.miracum.org/cbioportal/genome-nexus-db:${RELEASE:-latest}
+    volumes:
+      - genomenexus_data:/bitnami/mongodb
     environment:
       - REF_ENSEMBL_VERSION=grch37_ensembl92
       - SPECIES=homo_sapiens
@@ -146,3 +148,4 @@ volumes:
   cbioportal_data:
   cbioportal_session_data:
   fhir_data:
+  genomenexus_data:


### PR DESCRIPTION
Right now the Genome Nexus database acts just as a cache that is being reseted and reimported every time the container gets recreated. I think it makes sense to keep this data, so I would propose to store it on a separate volume.

Right now the data that is being shipped with the container gets imported on every recreation. This is another thing to figure out but not addressed in this PR.