### PR TITLE
Use official backend for build

### DIFF
--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -13,9 +13,11 @@
 # (see: stackoverflow.com/questions/56278325)
 FROM maven:3-openjdk-11 as build
 
-RUN git clone --single-branch --branch therapy_recommendation https://github.com/nr23730/cbioportal.git /cbioportal
+ARG VERSION=3.6.2
+
+RUN git clone --single-branch --branch v${VERSION} https://github.com/cbioportal/cbioportal.git /cbioportal
 WORKDIR /cbioportal
-RUN mvn -DskipTests clean install
+RUN mvn -DskipTests -Dfrontend.version=release${VERSION}-SNAPSHOT -Dfrontend.groupId=com.github.nr23730 clean install
 RUN unzip /cbioportal/portal/target/cbioportal*.war -d /unzipped
 
 FROM alpine:3.12.1


### PR DESCRIPTION
As we now use the `init.yml` for initialization which also generated a fully featured config file including the credentials for the MySQL-Server.

This means that all our changes to the backend are not required anymore and can be abandoned. Instead we can inject parameters to include our custom frontend into the build as done in this contribution.