### PR TITLE
Update to v3.6.16

### DIFF
--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -13,7 +13,7 @@
 # (see: stackoverflow.com/questions/56278325)
 FROM maven:3-openjdk-11 as build
 
-ARG VERSION=3.6.6
+ARG VERSION=3.6.14
 
 RUN git clone --single-branch --branch release${VERSION} https://github.com/nr23730/cbioportal-frontend.git /frontend
 WORKDIR /frontend

--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -13,7 +13,7 @@
 # (see: stackoverflow.com/questions/56278325)
 FROM maven:3-openjdk-11 as build
 
-ARG VERSION=3.6.14
+ARG VERSION=3.6.16
 
 RUN git clone --single-branch --branch release${VERSION} https://github.com/nr23730/cbioportal-frontend.git /frontend
 WORKDIR /frontend


### PR DESCRIPTION
3.6.16 also contains a fix for the clinical trials tab, as before the tab key was conflicting with the pathway tab.