### PR TITLE
add volume for portalinfo

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,6 +19,7 @@ services:
      - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
      - ./config/frontend.json:/cbioportal/frontend.json:ro
      - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
+     - cbioportal_portalinfo:/cbioportal/portalinfo
     depends_on:
      - cbioportal_database
      - cbioportal_session
@@ -252,5 +253,6 @@ networks:
 volumes:
   cbioportal_data:
   cbioportal_session_data:
+  cbioportal_portalinfo:
   fhir_data:
   genomenexus_data:

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -15,6 +15,7 @@ services:
      - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml
      - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
      - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
+     - cbioportal_portalinfo:/cbioportal/portalinfo
     depends_on:
      - cbioportal_database
      - cbioportal_session
@@ -163,4 +164,5 @@ networks:
 volumes:
   cbioportal_data:
   cbioportal_session_data:
+  cbioportal_portalinfo:
   genomenexus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
      - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
      - ./config/frontend.json:/cbioportal/frontend.json:ro
      - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
+     - cbioportal_portalinfo:/cbioportal/portalinfo
     depends_on:
      - cbioportal_database
      - cbioportal_session
@@ -221,5 +222,6 @@ networks:
 volumes:
   cbioportal_data:
   cbioportal_session_data:
+  cbioportal_portalinfo:
   fhir_data:
   genomenexus_data:

--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -79,4 +79,5 @@ RUN echo "cd /cbioportal/core/src/main/scripts && ./dumpPortalInfo.pl \$1" >> /c
 
 # switch to non-root user
 USER cbioportal
+RUN mkdir /cbioportal/portalinfo
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
currently the portalinfo will be written to `/cbioportal/portalinfo` inside the container. My proposal is writing this to a separate volume. This would also allow to use temporary containers using `docker-compose run --rm` for data import instead of using `docker-compose exec` which will use the container that is already running cbioportal.