### PR TITLE
don't skip loh mutations on import

### DIFF
--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /cbioportal
 
 # don't skip LoH mutations on import
 RUN sed -i 's/|| loh ||/||/' core/src/main/java/org/mskcc/cbio/portal/util/ExtendedMutationUtil.java
+RUN sed -i 's/safeStringTest( mutation.getMutationStatus(), "LOH" )/false/' core/src/main/java/org/mskcc/cbio/portal/scripts/MutationFilter.java
 
 RUN mvn -DskipTests -Dfrontend.version=0.3.0 -Dfrontend.groupId=com.github.cbioportal clean install
 RUN unzip /cbioportal/portal/target/cbioportal*.war -d /unzipped

--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -77,6 +77,9 @@ COPY --from=build /cbioportal/docker/web-and-data/docker-entrypoint.sh /usr/loca
 # script for calling dumpPortalInfo.py from docker-compose
 RUN echo "cd /cbioportal/core/src/main/scripts && ./dumpPortalInfo.pl \$1" >> /cbioportal/dumpPortalInfo.sh
 
+# don't skip LoH mutations on import
+RUN sed -i 's/\[\x27loh\x27, /[/' /cbioportal/core/src/main/scripts/importer/validateData.py
+
 # switch to non-root user
 USER cbioportal
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/services/cbioportal/Dockerfile
+++ b/services/cbioportal/Dockerfile
@@ -21,6 +21,10 @@ RUN mvn clean install
 
 RUN git clone --single-branch --branch v${VERSION} https://github.com/cbioportal/cbioportal.git /cbioportal
 WORKDIR /cbioportal
+
+# don't skip LoH mutations on import
+RUN sed -i 's/|| loh ||/||/' core/src/main/java/org/mskcc/cbio/portal/util/ExtendedMutationUtil.java
+
 RUN mvn -DskipTests -Dfrontend.version=0.3.0 -Dfrontend.groupId=com.github.cbioportal clean install
 RUN unzip /cbioportal/portal/target/cbioportal*.war -d /unzipped
 


### PR DESCRIPTION
This is intended to work together with nr23730/cbioportal-frontend#60.
The change will be effective for all new imported data as before LoH was skipped during the import process.