### PR TITLE
use cached mutationassessor documents

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -213,6 +213,9 @@ services:
       "-Dspring.data.mongodb.uri=mongodb://genomenexus_db:27017/annotator",
       "-Dvep.url=http://ensembl-rest:3000/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1",
       "-Dgenexrefs.url=http://ensembl-rest:3000/xrefs/id/ACCESSION?content-type=application/json",
+      "-Densembl.sequence.url=http://localhost:3000/sequence/region/human/QUERY?content-type=application/json",
+      "-DmutationAssessor.url=http://127.0.0.1/VARIANT&frm=json&fts=input,rgaa,rgvt,msa,pdb,F_impact,F_score,vc_score,vs_score,info,var,gene,uprot,rsprot,gaps,msa_height,chr,rs_pos,rs_res,up_pos,up_res,cnt_cosmic,cnt_snps",
+      "-Dmyvariantinfo.url=http://127.0.0.1/VARIANT",
       "-jar",
       "/app/genome-nexus.war"
     ]

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -130,6 +130,9 @@ services:
       "-Dspring.data.mongodb.uri=mongodb://genomenexus_db:27017/annotator",
       "-Dvep.url=http://ensembl-rest:3000/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1",
       "-Dgenexrefs.url=http://ensembl-rest:3000/xrefs/id/ACCESSION?content-type=application/json",
+      "-Densembl.sequence.url=http://localhost:3000/sequence/region/human/QUERY?content-type=application/json",
+      "-DmutationAssessor.url=http://127.0.0.1/VARIANT&frm=json&fts=input,rgaa,rgvt,msa,pdb,F_impact,F_score,vc_score,vs_score,info,var,gene,uprot,rsprot,gaps,msa_height,chr,rs_pos,rs_res,up_pos,up_res,cnt_cosmic,cnt_snps",
+      "-Dmyvariantinfo.url=http://127.0.0.1/VARIANT",
       "-jar",
       "/app/genome-nexus.war"
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,6 +186,9 @@ services:
       "-Dspring.data.mongodb.uri=mongodb://genomenexus_db:27017/annotator",
       "-Dvep.url=http://ensembl-rest:3000/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1",
       "-Dgenexrefs.url=http://ensembl-rest:3000/xrefs/id/ACCESSION?content-type=application/json",
+      "-Densembl.sequence.url=http://localhost:3000/sequence/region/human/QUERY?content-type=application/json",
+      "-DmutationAssessor.url=http://127.0.0.1/VARIANT&frm=json&fts=input,rgaa,rgvt,msa,pdb,F_impact,F_score,vc_score,vs_score,info,var,gene,uprot,rsprot,gaps,msa_height,chr,rs_pos,rs_res,up_pos,up_res,cnt_cosmic,cnt_snps",
+      "-Dmyvariantinfo.url=http://127.0.0.1/VARIANT",
       "-jar",
       "/app/genome-nexus.war"
     ]


### PR DESCRIPTION
In our last JourFixe we discussed slow response times on GenomeNexus and often occurring error messages with mutation assessor.

I uploaded a new [genome-nexus-db image](https://github.com/buschlab/MIRACUM-cbioportal/pkgs/container/genome-nexus-db). This now contains all annotations available in mutation assessor. 
With this PR I set all references to it's API to 127.0.0.1, so that they quickly return nothing. This is necessary because not mutation is present in mutation assessor, so it will still try to connect to that slow API from time to time.

Now GenomeNexus is very fast and fulfils requests almost immediately!

I will also try to bring this into the GenomeNexus repository, but therefore need integrate this into their Makefile for data download/transformation.