### PR TITLE
Pin version tag of openresty image

### DIFF
--- a/services/cbioproxy/Dockerfile
+++ b/services/cbioproxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/buschlab/cbioportal:${RELEASE:-latest} as static
 
-FROM openresty/openresty:alpine-fat
+FROM openresty/openresty:1.19.9.1-3-alpine-fat
 RUN apk update && apk add git
 COPY --from=static /cbioportal-webapp /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf \


### PR DESCRIPTION
This is the proper solution to fix problems that lead to the build issue of the cbioproxy service. The problem itself was fixed in fb555d3592d8f807fa0051909a1b203cb3fa047a but this prevents to let this happen again. Now Renovate will suggest new tags and automatically apply CI to this. 