### PR TITLE
only login once

### DIFF
--- a/services/cbioproxy/cbioportal.conf
+++ b/services/cbioproxy/cbioportal.conf
@@ -60,6 +60,11 @@ server
   location /
   {
 
+    if ($NGINX_LOGINREQUIRED = 'true')
+    {
+      include /etc/nginx/conf.d/lua_auth_config.lua;
+    }
+
     proxy_headers_hash_max_size 512;
     proxy_headers_hash_bucket_size 64;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
Right now login is required two times:
1. For cBioPortal via SAML
2. For therapy recommendation using OIDC/OAuth

However, logging in via SAML does not store the login information for OICD/OAuth but the reverse direction does work!

Therefore I propose to let the user login via OIDC/OAuth in the first place, which then results in a session that will also be used for SAML. 

So in the end this little change allows to use cBioPortal AND the therapy recommendation with only one login prompt.