### PR TITLE
Changes to make LocalCT tab available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+compose.override.yml
 data/*.sql
 data/*.sql.gz
 !data/tableExtension.sql

--- a/compose/mtb.yml
+++ b/compose/mtb.yml
@@ -50,6 +50,7 @@ services:
       - ./../services/cbioproxy/lua_auth_config.lua:/etc/nginx/conf.d/lua_auth_config.lua:Z
       - ./../services/cbioproxy/lua_login_config.lua:/etc/nginx/conf.d/lua_login_config.lua:Z
       - ./../config/attributes.json:/attributes.json:Z
+      - ./../config/localCT.json:/localCT.json:Z
       - ./../data/tumorTypes.json:/tumorTypes.json:Z
       - ./../config/keycloak.pem:/keycloak.pem:z
     environment:

--- a/config/frontend.json
+++ b/config/frontend.json
@@ -1,4 +1,5 @@
 {
   "cancerdrugsUrl": "https://componc.github.io/cancerdrugs",
-  "cancerdrugsJsonUrl": "https://componc.github.io/cancerdrugs/data/drugs/"
+  "cancerdrugsJsonUrl": "https://componc.github.io/cancerdrugs/data/drugs/",
+  "local_ct_enabled": false
 }

--- a/config/localCT.json
+++ b/config/localCT.json
@@ -1,0 +1,96 @@
+{
+	"studies": [
+		{
+			"trialName": "EXAMPLE SNV Trial 1: MK-6482-015-Phase2",
+			"trialUrl": "https://clinicaltrials.gov/study/NCT04924075",
+			"inclusionCriteria": [
+				"EPAS1:MUT",
+				"FH:MUT",
+				"SDHA:MUT",
+				"SDHB:MUT",
+				"SDHC:MUT",
+				"SDHD:MUT",
+				"SDHAF2:MUT",
+				"EGLN1:MUT",
+				"EGLN2:MUT",
+				"MDH1:MUT",
+				"MDH2:MUT",
+				"ELOC:MUT"
+			],
+			"exclusionCriteria": [],
+			"min_age": 12
+		},
+		{
+			"trialName":"EXAMPLE SNV Trial 2: Soratram",
+			"trialUrl":"https://www.quickqueck.de/detail/228/",
+			"inclusionCriteria":[
+				"BRAF:G460R",
+				"BRAF:G466A",
+				"BRAF:G466R",
+				"BRAF:G466V",
+				"BRAF:G466E",
+				"BRAF:N581S",
+				"BRAF:N581T",
+				"BRAF:N581I",
+				"BRAF:N581D",
+				"BRAF:D594E",
+				"BRAF:D594G",
+				"BRAF:D594N",
+				"BRAF:D594H",
+				"BRAF:A598T",
+				"BRAF:G596R"],
+			"exclusionCriteria":[
+				"BRAF:V600E",
+				"BRAF:V600K",
+				"BRAF:V600D",
+				"BRAF:V600R",
+				"BRAF:V600M"
+			],
+			"min_age": 18
+		},
+		{
+			"trialName":"EXAMPLE CNV Trial: ECI830 Single Agent or in Combination",
+			"trialUrl":"https://clinicaltrials.gov/study/NCT06726148",
+			"inclusionCriteria":[
+				"CCNE1:AMP",
+				"CCNE1:GAIN"
+			],
+			"exclusionCriteria":[],
+			"min_age": 18
+		},
+		{
+			"trialName":"EXAMPLE Fusion Trial",
+			"trialUrl":"about:blank",
+			"inclusionCriteria":[
+				"TMPRSS2:ERG:FUSION",
+				"EML4:ALK:FUSION",
+				"ETV6:NTRK3:FUSION",
+				"FGFR3:TACC3:FUSION",
+				"SS18:SSX1:FUSION",
+				"BRAF:FUSION"
+			],
+			"exclusionCriteria":[],
+			"min_age": 50,
+			"max_age": 70
+		},
+		{
+			"trialName": "EXAMPLE Clinical Parameter Trial 1: HLA-A*02:01 Positive",
+			"trialUrl": "about:blank",
+			"inclusionCriteria": [
+				"Clinical:HLA:string:contains:A*02\\:01"
+			],
+			"exclusionCriteria": [],
+			"min_age": 18,
+			"max_age": 65
+		},
+		{
+			"trialName": "EXAMPLE Clinical Parameter Trial 2: TMB High",
+			"trialUrl": "about:blank",
+			"inclusionCriteria": [
+				"Clinical:CVR_TMB_SCORE:number:>:10"
+			],
+			"exclusionCriteria": [],
+			"max_age": 70
+		}
+	]
+}

--- a/services/cbioproxy/cbioportal.conf
+++ b/services/cbioproxy/cbioportal.conf
@@ -45,6 +45,23 @@ server
 
   }
 
+  location /localCT.json
+  {
+
+    if ($http_origin ~* "^http://localhost:3000$")
+    {
+      add_header Access-Control-Allow-Origin "$http_origin";
+    }
+
+    sendfile on;
+    sendfile_max_chunk 5m;
+    tcp_nopush on;
+    tcp_nodelay on;
+    root /;
+  
+  }
+
+
   location ~ (/content|/css|/Data|/db-scripts|/fonts|/gfx|/images|/js|/reactapp|/swf)$
   {
 


### PR DESCRIPTION
This PR adds the Local Clinical Trials Beta tab. In this Beta state, a reference json is read and matched with patient data obtained from the internal API.

Before authorizing the PR, please check if you can get the tab running in your cbioportal (localhost is sufficient).

1. Build an image with the [local_trials](https://github.com/PM4Onco/cbioportal-frontend/tree/local_trials) cbioportal-frontend branch.
2. enable the tab via [frontend.json](https://github.com/PM4Onco/MTB-cbioportal/blob/local_trials/config/frontend.json): set   "local_ct_enabled": true (I have disabled the feature per default, as it's a Beta feature and requires extra maintenance). As of now, I have not found a way to pass this via a variable in .env, since I believe it has to be passed to the frontend via cbioportal-core, for which we do not maintain an extra repo, but use the official repo of MSKCC. If you know a better way, feel free to implement it.
3. start cbioportal with the frontend image, if you can see the Local Clinical Trials tab, it was successful.
It should look somewhat like this:
<img width="1311" height="877" alt="image" src="https://github.com/user-attachments/assets/b4e3e2dc-74e8-484e-98fa-93179dc160ac" />

4. The trials can be altered loaded via [localCT.json](https://github.com/PM4Onco/MTB-cbioportal/blob/local_trials/config/localCT.json). Not necessary for the PR, but I would be happy if you played around with this.

"trialName": string (displayed trial name),
"trialUrl" (optional): string(linked trial URL),
"inclusionCriteria": [string] (see below),
"exclusionCriteria" (optional): [string] (see below),
"min_age" (optional): int (age range lower bound),
"max_age" (optional): int (age range apper bound)

optional criteria can simply be left out.

The syntax for inclusion and exclusion criteria is similar to OQL:
\<GENE\>:\<AACHANGE\> for specific SNVs/Mutations in \<GENE\>
\<GENE\>:MUT for all mutations in \<GENE\>
\<GENE\>:\<CNV_TYPE\> for the corresponding \<CNV_TYPE\> (_i.e._ AMP|GAIN|HETLOSS|HOMDEL) in \<GENE\>
\<GENE\>:FUSION for all Fusions with \<GENE\> as fusion partner
\<GENE1\>:\<GENE2\>:FUSION for all fusions containing <GENE1> and <GENE2> (_i.e._ \<GENE1\>::\<GENE2\> or \<GENE2>::\<GENE1\>)

It's also possible to look for clinical attributes, but because they are so diverse, a general language was quite difficult to develop, so the search term is more complicated:

Clinical:\<ATTRIBUTE\>:\<DATA_TYPE\>:\<OPERATOR\>:\<VALUE>
\<ATTRIBUTE\> must match the Attribute name in the database, not the display name. So it depends on how you load clinical data to cBioPortal
\<DATA_TYPE\> must be string or number.
\<OPERATOR\> can be one of the following: ('>', '>=', '<', '<=', '=', '!=', 'contains')
\<VALUE\> is the rererence value. 
so if you use 
- "Clinical:HLA:string:contains:A*02\\:01" it will search the \<ATTRIBUTE\> HLA, which is of the \<DATA_TYPE\> string for all strings that contain A*02:01
- "Clinical:CVR_TMB_SCORE:number:>:10" will search the \<ATTRIBUTE\> CVR_TMB_SCORE, which is of the \<DATA_TYPE\> number for all values >10.

Please contact me if you have any questions or suggestions.